### PR TITLE
Allow pinning certificates to be added at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.1
+
+- Added addPinningCerts function for adding new pinning certificates at runtime
+
 ## v1.2.0
 
 - Added support for TLSv1.1 and TLSv1.2 for android versions 4.1-4.4 (API levels 16-19)

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ As an alternative, you can store your .cer files in the www/certificates folder.
         console.log('error :(');
     });
     
+### addPinningCerts
+Add additional certificates to pin against at runtime.
+
+If you have a secure channel to distribute certificates, you can update certificates at runtime. This allows you to rotate expired certificates without having to force users to update their app.
+
+After SSL pinning has been enabled you can add Base64 DER encoded certificates.
+
+    CordovaHttpPlugin.addPinningCerts(['MIIEyzCCA7OgAwIBA...', 'MIIFHzCCBAegAwIBA...'], function() {
+        console.log('success!');
+    }, function() {
+        console.log('error :(');
+    });
+    
 ### acceptAllCerts
 Accept all SSL certificates.  Or disable accepting all certificates.  This defaults to false.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-http",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Cordova / Phonegap plugin for communicating with HTTP servers using SSL pinning",
   "cordova": {
     "id": "cordova-plugin-http",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="cordova-plugin-http"
-  version="1.2.0">
+  version="1.2.1">
 
     <name>SSL Pinning</name>
  

--- a/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
+++ b/src/android/com/synconset/CordovaHTTP/CordovaHttpPlugin.java
@@ -4,6 +4,7 @@
 package com.synconset;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -16,6 +17,7 @@ import java.security.cert.X509Certificate;
 import java.util.Iterator;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -79,6 +81,15 @@ public class CordovaHttpPlugin extends CordovaPlugin {
             } catch(Exception e) {
                 e.printStackTrace();
                 callbackContext.error("There was an error setting up ssl pinning");
+            }
+        } else if (action.equals("addPinningCerts")) {
+            try {
+                List<String> certs = this.getStringListFromJSONArray(args);
+                this.addPinningCerts(certs);
+                callbackContext.success();
+            } catch(Exception e) {
+                e.printStackTrace();
+                callbackContext.error("There was an error adding pinning certs");
             }
         } else if (action.equals("acceptAllCerts")) {
             boolean accept = args.getBoolean(0);
@@ -150,6 +161,14 @@ public class CordovaHttpPlugin extends CordovaPlugin {
         }
     }
 
+    private void addPinningCerts(List<String> certs) throws GeneralSecurityException, IOException {
+        for (String cert : certs) {
+            byte[] certBytes = Base64.decode(cert, Base64.NO_WRAP);
+            InputStream caInput = new ByteArrayInputStream(certBytes);
+            HttpRequest.addCert(caInput);
+        }
+    }
+
     private HashMap<String, String> getStringMapFromJSONObject(JSONObject object) throws JSONException {
         HashMap<String, String> map = new HashMap<String, String>();
         Iterator<?> i = object.keys();
@@ -170,5 +189,14 @@ public class CordovaHttpPlugin extends CordovaPlugin {
             map.put(key, object.get(key));
         }
         return map;
+    }
+
+    private List<String> getStringListFromJSONArray(JSONArray array) throws JSONException {
+        List<String> list = new ArrayList<String>();
+
+        for (int i = 0; i < array.length(); i++) {
+            list.add(array.getString(i));
+        }
+        return list;
     }
 }

--- a/src/ios/CordovaHttpPlugin.h
+++ b/src/ios/CordovaHttpPlugin.h
@@ -5,6 +5,7 @@
 @interface CordovaHttpPlugin : CDVPlugin
 
 - (void)enableSSLPinning:(CDVInvokedUrlCommand*)command;
+- (void)addPinningCerts:(CDVInvokedUrlCommand*)command;
 - (void)acceptAllCerts:(CDVInvokedUrlCommand*)command;
 - (void)validateDomainName:(CDVInvokedUrlCommand*)command;
 - (void)post:(CDVInvokedUrlCommand*)command;

--- a/src/ios/CordovaHttpPlugin.m
+++ b/src/ios/CordovaHttpPlugin.m
@@ -46,6 +46,20 @@
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
+- (void)addPinningCerts:(CDVInvokedUrlCommand*)command {
+    NSArray *certificates = [command.arguments objectAtIndex:0];
+    NSMutableSet <NSData *> *pinnedCertificates = [NSMutableSet setWithSet:[securityPolicy pinnedCertificates]];
+
+    for (NSString *base64Certificate in certificates) {
+        NSData *certificateData = [[NSData alloc] initWithBase64EncodedString:base64Certificate options:0];
+        [pinnedCertificates addObject:certificateData];
+    }
+    [securityPolicy setPinnedCertificates:[pinnedCertificates copy]];
+
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
 - (void)acceptAllCerts:(CDVInvokedUrlCommand*)command {
     CDVPluginResult* pluginResult = nil;
     bool allow = [[command.arguments objectAtIndex:0] boolValue];

--- a/www/cordovaHTTP.js
+++ b/www/cordovaHTTP.js
@@ -40,6 +40,9 @@ var http = {
     enableSSLPinning: function(enable, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "enableSSLPinning", [enable]);
     },
+    addPinningCerts: function(certs, success, failure) {
+        return exec(success, failure, "CordovaHttpPlugin", "addPinningCerts", [certs]);
+    },
     acceptAllCerts: function(allow, success, failure) {
         return exec(success, failure, "CordovaHttpPlugin", "acceptAllCerts", [allow]);
     },
@@ -145,6 +148,9 @@ if (typeof angular !== "undefined") {
             },
             enableSSLPinning: function(enable) {
                 return makePromise(http.enableSSLPinning, [enable]);
+            },
+            addPinningCerts: function(certs) {
+                return makePromise(http.addPinningCerts, [certs]);
             },
             acceptAllCerts: function(allow) {
                 return makePromise(http.acceptAllCerts, [allow]);


### PR DESCRIPTION
If you have a secure channel to distribute certificates, you can update certificates at runtime.
This allows you to rotate expired certificates without having to force users to update their app.